### PR TITLE
fix: Delay to SplineScene load

### DIFF
--- a/docs/releaseNotes/releaseNotesV1.md
+++ b/docs/releaseNotes/releaseNotesV1.md
@@ -6,6 +6,8 @@
 
 ## Fixes
 
+- Adding a delay to the rendering of `SplineScene` so that `mouseDown` events are consistent
+
 ## Work in Progress
 
 - Adding placeholder iFrame for interactive 3D macropad navigation

--- a/src/components/ui/atoms/SplineScene/SplineScene.jsx
+++ b/src/components/ui/atoms/SplineScene/SplineScene.jsx
@@ -14,17 +14,23 @@ export default function SplineScene({
   const [isLoading, setIsLoading] = useState(true);
   const theme = useTheme();
 
+  const delaySceneLoad = setTimeout(() => {
+    setIsLoading(false);
+  }, 300);
+
   return (
     <Suspense>
       <Wrapper>
         {isLoading && <ThreeDots color={loaderColor ?? theme?.core?.['50']} />}
 
-        <Spline
-          onLoad={() => setIsLoading(false)}
-          scene={scene}
-          onMouseDown={onMouseDown}
-          {...props}
-        />
+        {!isLoading && (
+          <Spline
+            onLoad={() => delaySceneLoad}
+            scene={scene}
+            onMouseDown={onMouseDown}
+            {...props}
+          />
+        )}
       </Wrapper>
     </Suspense>
   );


### PR DESCRIPTION
Adding a delay to the `SplineScene` load so that the spline scene is able to render more consistently, allowing for more accurate/repeatable `mouseDown` events.